### PR TITLE
Upgrade prefect 2.0.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM prefecthq/prefect:2.0b8-python3.8
+FROM prefecthq/prefect:sha-39db6fb-python3.10
 
 RUN apt update && \
     apt install -y vim && \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 IMAGE_NAME := prefect-orion
-IMAGE_TAG := beta8
+IMAGE_TAG := sha-39db6fb-python3.10
 IMAGE := ${IMAGE_NAME}:${IMAGE_TAG}
 IMAGE_HASH := $(shell command docker images -q ${IMAGE} 2> /dev/null)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ and Minio for flow storage
 
 + Give the start command a few seconds, specially the first time since postgres
   and prefect need to be initialized
++ Open the [MinIO Console](http://prefect-server:9001) in your browser and
+  verify it's up and running. If so, create a private bucket named `prefect` to
+  be referenced by the storage block created by the initialization script.
 + Open [Prefect UI](http://prefect-server:4200) in your browser and verify that
   it's up and running
 + Deploy test flow

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,6 @@ networks:
   prefect:
     name: prefect
 
-
 services:
   # --------------------------------------#
   #               Postgres                #
@@ -26,18 +25,18 @@ services:
       test: pg_isready -q -d $${POSTGRES_DB} -U $${POSTGRES_USER} | grep "accepting connections" || exit 1
       timeout: 2s
     ports:
-    - published: 5433
-      target: 5432
+    - 15432:5432
     restart: on-failure
     volumes:
       - ./volumes/postgres:/var/lib/postgresql/data
     networks:
       - prefect
+
   # --------------------------------------#
   #             Prefect Server            #
   # --------------------------------------#
   prefect-server:
-    image: prefect-orion:beta8
+    image: prefect-orion:sha-39db6fb-python3.10
     command:
       - prefect
       - orion
@@ -58,11 +57,12 @@ services:
       PREFECT_API_URL: http://prefect-server:4200/api
     networks:
       - prefect
+
   # --------------------------------------#
-  #             Docker Agent              #
+  #         Prefect Docker Agent          #
   # --------------------------------------#
   prefect-agent:
-    image: prefect-orion:beta8
+    image: prefect-orion:beta8sha-39db6fb-python3.10
     command:
       - prefect
       - agent
@@ -92,9 +92,7 @@ services:
       - ./volumes/minio:/data
     command: server /data --console-address :9001
     ports:
-      - published: 9000
-        target: 9000
-      - published: 9001
-        target: 9001
+      - 9000:9000
+      - 9001:9001
     networks:
       - prefect

--- a/prefect.sh
+++ b/prefect.sh
@@ -97,6 +97,8 @@ function stop() {
 function reset() {
     echo 'deleting ALL prefect data'
     rm -rf volumes
+    rm -f .env
+    rm -f flows/prefect.env
     echo 'done!'
 }
 


### PR DESCRIPTION
Revised to make use of the 2.0.4 release of Prefect. Modifies the dockerfile, makefile, and the docker-compose file. Also includes revisions to the initialization python script to make use of current Prefect structures (primarily, revisions within the storage block construct, related to Minio's s3-style storage).